### PR TITLE
Add optional nuclei scanning and takeover detection

### DIFF
--- a/ReconMasta.sh
+++ b/ReconMasta.sh
@@ -13,10 +13,13 @@ trap 'echo -e "${RED}[!] Algo falló. Abortando.${NC}" >&2' ERR
 
 # 🧠 Verbosidad
 VERBOSE=0
+NUCLEI_CHOICE="ask"
 while [[ $# -gt 0 ]]; do
     case "$1" in
         -v) VERBOSE=1 ;;
         -vv) VERBOSE=2 ;;
+        --nuclei) NUCLEI_CHOICE="yes" ;;
+        --no-nuclei) NUCLEI_CHOICE="no" ;;
     esac
     shift
 done
@@ -28,6 +31,16 @@ read -p "🔎 Empresa: " empresa
 read -p "🌐 Dominio objetivo (ej: example.com): " dominio
 read -p "🔑 ¿Usar tus APIs de Amass? (s/n): " usar_apis
 fecha=$(date +%Y-%m-%d)
+
+# Decidir ejecución de Nuclei
+if [[ "$NUCLEI_CHOICE" == "ask" ]]; then
+    read -p "🚀 ¿Ejecutar Nuclei después de resolver hosts? (s/n): " resp_nuclei
+    if [[ "$resp_nuclei" == "s" ]]; then
+        NUCLEI_CHOICE="yes"
+    else
+        NUCLEI_CHOICE="no"
+    fi
+fi
 
 # 📁 Estructura
 empresa_slug=$(echo "$empresa" | tr '[:upper:]' '[:lower:]' | sed 's/[^a-z0-9]/_/g')
@@ -89,8 +102,28 @@ fi
 log "${YELLOW}[*] Resolviendo con httpx...${NC}"
 touch "$subs/subdominios.txt"
 touch "$subs/hosts_vivos.txt"
+touch "$subs/hosts_urls.txt"
 if command -v httpx &>/dev/null; then
     cat "$subs/subdominios.txt" | httpx --threads 50 -sc -title -ip -td -probe -o "$subs/hosts_vivos.txt"
+    awk '{print $1}' "$subs/hosts_vivos.txt" > "$subs/hosts_urls.txt"
+fi
+
+# 🔬 Escaneo con Nuclei
+if [[ "$NUCLEI_CHOICE" == "yes" ]]; then
+    log "${YELLOW}[*] Escaneando con Nuclei...${NC}"
+    if command -v nuclei &>/dev/null; then
+        nuclei -l "$subs/hosts_urls.txt" -o "$scan/nuclei.txt"
+    else
+        log "${RED}[!] 'nuclei' no está instalado. Saltando.${NC}"
+    fi
+fi
+
+# 🛠 Comprobación de subdomain takeover
+log "${YELLOW}[*] Comprobando posibles subdomain takeovers...${NC}"
+if command -v subjack &>/dev/null; then
+    subjack -w "$subs/subdominios.txt" -t 100 -timeout 30 -ssl -o "$scan/takeover.txt" -v
+else
+    log "${RED}[!] 'subjack' no está instalado. Saltando comprobación de takeover.${NC}"
 fi
 
 # 🚩 Infraestructura directa detectada (OVH, DigitalOcean, etc.)
@@ -128,12 +161,16 @@ fi
 # 📄 Resumen
 total_subs=$(wc -l < "$subs/subdominios.txt" 2>/dev/null || echo 0)
 total_vivos=$(wc -l < "$subs/hosts_vivos.txt" 2>/dev/null || echo 0)
+nuclei_hallazgos=$(wc -l < "$scan/nuclei.txt" 2>/dev/null || echo 0)
+takeover_hallazgos=$(wc -l < "$scan/takeover.txt" 2>/dev/null || echo 0)
 
 {
     echo "🗓 Recon para $empresa - $dominio"
     echo "📅 Fecha: $(date)"
     echo "🔎 Subdominios únicos:     $total_subs"
     echo "🌐 Hosts con respuesta:    $total_vivos"
+    echo "🚨 Hallazgos de Nuclei:    $nuclei_hallazgos"
+    echo "🎣 Posibles takeovers:     $takeover_hallazgos"
     echo "📁 Resultados en:          $base"
 } > "$base/resumen.txt"
 


### PR DESCRIPTION
## Summary
- add `--nuclei` and `--no-nuclei` CLI flags
- ask user whether to run nuclei if no flag was provided
- run `nuclei` on resolved hosts and optionally skip it
- detect potential subdomain takeovers with `subjack`
- extend `resumen.txt` with findings counts

## Testing
- `bash -n ReconMasta.sh`

------
https://chatgpt.com/codex/tasks/task_e_683f8fb87fb8832aa45d3799ca5d64af