### PR TITLE
Add debug logging and fix pipeline errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,3 +12,20 @@ sudo ./setup.sh
 
 After installation you can run `ReconMasta.sh` normally.
 
+## Usage
+
+```
+./ReconMasta.sh [options]
+```
+
+Options:
+
+- `-v`    : verbose output
+- `-vv`   : very verbose output
+- `-d` or `--debug` : enable debug mode and log all commands to `run.log`
+- `--nuclei` : run Nuclei automatically
+- `--no-nuclei` : skip Nuclei step
+
+When debug mode is enabled, a `run.log` file will be created inside the generated
+results folder containing a full command trace.
+


### PR DESCRIPTION
## Summary
- add debug flag with `-d`/`--debug`
- pipe output to `run.log` and enable tracing when debug mode is used
- avoid failures on empty grep results
- document new option in README

## Testing
- `bash -n ReconMasta.sh`
- `shellcheck ReconMasta.sh`

------
https://chatgpt.com/codex/tasks/task_e_68406bef19f0832ab03cd76c00473a02