### PR TITLE
Read httpx flags from config

### DIFF
--- a/Framework/modules/resolve_hosts.sh
+++ b/Framework/modules/resolve_hosts.sh
@@ -1,11 +1,16 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+CONFIG_FILE="config.yaml"
+
 SUBFILE="$1/subdominios.txt"
 OUTFILE="$1/hosts_vivos.txt"
 URLFILE="$1/hosts_urls.txt"
 
+# Leer flags de httpx desde config.yaml
+HTTPX_FLAGS=$(grep '^httpx_flags:' "$CONFIG_FILE" | cut -d':' -f2- | xargs)
+
 echo "[*] Resolving and probing hosts with httpx..."
 
-httpx -l "$SUBFILE" --threads 50 -sc -title -ip -td -probe -o "$OUTFILE"
+httpx -l "$SUBFILE" $HTTPX_FLAGS -o "$OUTFILE"
 awk '{print $1}' "$OUTFILE" > "$URLFILE"


### PR DESCRIPTION
## Summary
- read `httpx_flags` from `config.yaml`
- apply the flags when running `httpx`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68410f2ed774832a97b6f5c9f517cec8